### PR TITLE
Do not check if options and locals are objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ exports.inputFormats = ['transparency'];
 exports.outputFormat = 'html';
 
 exports.render = function (str, options, locals) {
-  options = options && typeof options === 'object' ? options : {};
-  locals = locals && typeof locals === 'object' ? locals : {};
-
   var data = extend({}, options, locals);
   return transparency.render(str, data);
 };


### PR DESCRIPTION
`extend` already checks them, and even if we don't check them it doesn't really matter anyway. The app will blow up sooner or later.
